### PR TITLE
Removing PVC `rhche-prometheus-data` definition from the template

### DIFF
--- a/openshift/che-monitoring.yaml
+++ b/openshift/che-monitoring.yaml
@@ -119,18 +119,6 @@ objects:
             secretName: app-sre-observability-htpasswd
     triggers:
     - type: ConfigChange
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: rhche-prometheus-data
-    labels:
-      app: rhche-prometheus
-  spec:
-    accessModes:
-    - ReadOnlyMany
-    resources:
-      requests:
-        storage: 1Gi
 parameters:
 - name: IMAGE
   value: prom/prometheus


### PR DESCRIPTION
My understanding that PVC definition should not be part of the template (I believe those are provisioned manually by SD with different capacity for prod / prod-preview e.g - https://github.com/redhat-developer/osd-monitor-poc/blob/master/osd-monitor.yml#L27 )