### PR TITLE
Revert "Removing recreate strategy from prometheus template"

### DIFF
--- a/openshift/che-monitoring.yaml
+++ b/openshift/che-monitoring.yaml
@@ -30,6 +30,11 @@ objects:
     name: rhche-prometheus
   spec:
     replicas: 1
+    strategy:
+      activeDeadlineSeconds: 21600
+      recreateParams:
+        timeoutSeconds: 700
+      type: Recreate
     selector:
       app: rhche-prometheus
       deploymentconfig: rhche-prometheus


### PR DESCRIPTION
Reverts redhat-developer/che-monitoring#22

We need to still specify recreate because the old pods will lock up the PV, and we don't want to manually scale down the last deployment every time